### PR TITLE
Change for upcoming tidytext release

### DIFF
--- a/R/stack_matrix.R
+++ b/R/stack_matrix.R
@@ -68,10 +68,10 @@ stack_to_matrix = tidy_to_matrix = function(my_df, col_to_row, col_to_col,
     # Sparse Matrix
     if (requireNamespace("tidytext", quietly = TRUE)) {
       if (is.null(col_value)) {
-        my_mat = tidytext::cast_sparse_(my_df, col_to_row, col_to_col)
+        my_mat = tidytext::cast_sparse(my_df, !!col_to_row, !!col_to_col)
       } else {
-        my_mat = tidytext::cast_sparse_(my_df, col_to_row, col_to_col,
-                                        col_value)
+        my_mat = tidytext::cast_sparse(my_df, !!col_to_row, !!col_to_col,
+                                       !!col_value)
       }
     } else {
       stop("The tidytext package need to be installed to get a sparse matrix")

--- a/tests/testthat/test-funrar.R
+++ b/tests/testthat/test-funrar.R
@@ -73,8 +73,8 @@ rownames(small_mat) = c("s1", "s2")
 small_df = matrix_to_tidy(small_mat)
 
 # Distinctiveness final data.frame
-undef_dist = data_frame(site = c("s1", "s2"), species = c("a", "b"),
-                        Di = rep(NaN, 2))
+undef_dist = tibble(site = c("s1", "s2"), species = c("a", "b"),
+                    Di = rep(NaN, 2))
 
 # Final distinctiveness matrix
 undef_dist_mat = table(undef_dist$site, undef_dist$species)

--- a/tests/testthat/test-scarcity.R
+++ b/tests/testthat/test-scarcity.R
@@ -64,8 +64,8 @@ rownames(small_mat) = c("s1", "s2")
 small_df = matrix_to_tidy(small_mat)
 
 # Distinctiveness final data.frame
-undef_dist = data_frame(site = c("s1", "s2"), species = c("a", "b"),
-                        Di = rep(NaN, 2))
+undef_dist = tibble(site = c("s1", "s2"), species = c("a", "b"),
+                    Di = rep(NaN, 2))
 
 # Final distinctiveness matrix
 undef_dist_mat = table(undef_dist$site, undef_dist$species)


### PR DESCRIPTION
The SE version of `cast_sparse_()` in tidytext has been soft deprecated for a very long time and the upcoming release will officially deprecate it for good. This PR fixes the problem! ✨

Let me know if there are any problems! I plan to submit to tidytext by this coming Friday, which will impact your package. I apologize for the short notice, but I am operating under a directive from CRAN to submit ASAP.

I also changed some soft-deprecated `data_frame()` in your tests to `tibble()` to avoid warnings.