### PR TITLE
Testthat v3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,8 +35,11 @@ Suggests:
     knitr,
     Matrix,
     rmarkdown,
-    testthat (>= 2.1.0),
+    testthat (>= 2.99.0),
     tidytext
 VignetteBuilder: knitr
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
+Config/testthat/edition: 3
+Remotes:
+    r-lib/testthat

--- a/tests/testthat/test-dist_matrix.R
+++ b/tests/testthat/test-dist_matrix.R
@@ -8,7 +8,7 @@ test_that("Returned object is a matrix", {
   rownames(trait_df) = letters[1:5]
 
   # Object is matrix
-  expect_is(compute_dist_matrix(trait_df), "matrix")
+  expect_true(inherits(compute_dist_matrix(trait_df), "matrix"))
 })
 
 

--- a/tests/testthat/test-dist_matrix.R
+++ b/tests/testthat/test-dist_matrix.R
@@ -53,16 +53,17 @@ test_that("Distance matrix contains good values", {
   dist_mat = suppressWarnings(compute_dist_matrix(other_mat))
 
   # Null diagonal
-  expect_equivalent(diag(dist_mat), rep(0, 4))
-  expect_equivalent(diag(t_dist_mat), rep(0, 5))
+  expect_equal(diag(dist_mat), rep(0, 4), ignore_attr = TRUE)
+  expect_equal(diag(t_dist_mat), rep(0, 5), ignore_attr = TRUE)
 
+  exp_dist_mat <- matrix(c(0, 1/3, 2/3, 1,
+                           1/3, 0, 1/3, 2/3,
+                           2/3, 1/3, 0, 1/3,
+                           1, 2/3, 1/3, 0),
+                         nrow = 4)
   # Expected values
-  expect_equivalent(dist_mat,
-                    matrix(c(0, 1/3, 2/3, 1,
-                             1/3, 0, 1/3, 2/3,
-                             2/3, 1/3, 0, 1/3,
-                             1, 2/3, 1/3, 0),
-                           nrow = 4))
+  expect_equal(unname(dist_mat), exp_dist_mat)
+
 })
 
 test_that("Different distances method give consistent results", {
@@ -110,17 +111,17 @@ test_that("Scaling works with continuous traits", {
   center_dist       = as.matrix(dist(scale(trait_df, TRUE, FALSE)))
   scale_dist        = as.matrix(dist(scale(trait_df, FALSE, TRUE)))
 
-  expect_equivalent(compute_dist_matrix(trait_df, center = TRUE, scale = TRUE,
-                                        metric = "euclidean"),
-                    center_scale_dist)
+  expect_equal(compute_dist_matrix(trait_df, center = TRUE, scale = TRUE,
+                                   metric = "euclidean"),
+               center_scale_dist)
 
-  expect_equivalent(compute_dist_matrix(trait_df, center = TRUE, scale = FALSE,
-                                        metric = "euclidean"),
-                    center_dist)
+  expect_equal(compute_dist_matrix(trait_df, center = TRUE, scale = FALSE,
+                                   metric = "euclidean"),
+               center_dist)
 
-  expect_equivalent(compute_dist_matrix(trait_df, center = TRUE, scale = TRUE,
-                                        metric = "euclidean"),
-                    center_scale_dist)
+  expect_equal(compute_dist_matrix(trait_df, center = TRUE, scale = TRUE,
+                                   metric = "euclidean"),
+               center_scale_dist)
 
   trait_df2 = trait_df
   trait_df2$trait3 = letters[1:4]

--- a/tests/testthat/test-distinctiveness.R
+++ b/tests/testthat/test-distinctiveness.R
@@ -166,10 +166,10 @@ test_that("Correct Di computation with different comm. without abundance",{
   c_dist = distinctiveness_stack(com_df, "species", "site", abund = NULL,
                                  dist_mat)
 
-  expect_equivalent(correct_dist_mat,
-                    as.table(distinctiveness(valid_mat, dist_mat)))
+  expect_equal(correct_dist_mat,
+               as.table(distinctiveness(valid_mat, dist_mat)))
 
-  expect_equivalent(c_dist, correct_dist)
+  expect_equal(c_dist, correct_dist)
 
   # Undefined distinctiveness for species alone in communities
   expect_equal(distinctiveness_com(com_df[1,], "species",
@@ -186,7 +186,7 @@ test_that("Correct Di computation with different comm. without abundance",{
 test_that("Di is undefined for a community with a single species", {
 
   ## Test for matrix version of distinctiveness
-  expect_equivalent(as(undef_dist_mat, "matrix"), undef_test)
+  expect_equal(as(undef_dist_mat, "matrix"), undef_test, ignore_attr = TRUE)
 
   # Check warning for NaN created in the matrix
   expect_warning(distinctiveness(small_mat, dist_mat),
@@ -220,7 +220,7 @@ test_that("Di is undefined for a community with a single species", {
 test_that("Distinctiveness works with sparse matrices", {
   expect_silent(distinctiveness(sparse_mat, dist_mat))
 
-  expect_equivalent(distinctiveness(sparse_mat, dist_mat), dist_sparse_mat)
+  expect_equal(distinctiveness(sparse_mat, dist_mat), dist_sparse_mat)
 })
 
 
@@ -307,20 +307,21 @@ test_that("Relative distinctiveness can be computed", {
 
   ## Only presence-absences
   # Matrix
-  expect_equivalent(distinctiveness(valid_mat, dist_mat, relative = TRUE),
-                    correct_rel_di)
+  expect_equal(distinctiveness(valid_mat, dist_mat, relative = TRUE),
+               correct_rel_di,
+               ignore_attr = TRUE)
   # Df
   expect_equal(distinctiveness_tidy(com_df, "species", "site",
                                     dist_matrix = dist_mat, relative = TRUE),
                correct_rel_di_df)
   # Sparse mat
-  expect_equivalent(distinctiveness(sparse_mat, dist_mat, relative = TRUE),
-                    dist_sparse_mat_rel)
+  expect_equal(distinctiveness(sparse_mat, dist_mat, relative = TRUE),
+               dist_sparse_mat_rel)
 
   # Single community
-  expect_equivalent(distinctiveness_com(com_df[1:2, ], "species",
+  expect_equal(distinctiveness_com(com_df[1:2, ], "species",
                                    dist_matrix = dist_mat, relative = TRUE),
-                    correct_rel_di_df[1:2, ])
+               correct_rel_di_df[1:2, ])
 
   ## With abundances
   # Matrix

--- a/tests/testthat/test-distinctiveness_alt.R
+++ b/tests/testthat/test-distinctiveness_alt.R
@@ -77,20 +77,20 @@ test_that("Correct Di computation without abundance",{
 
   # Check computation equal
   # T < 1/3
-  expect_equivalent(distinctiveness_alt(valid_mat, dist_mat, 1/10),
-                    good_di_0.1)
+  expect_equal(distinctiveness_alt(valid_mat, dist_mat, 1/10),
+               good_di_0.1)
 
   # 1/3 ≤ T < 1/2
-  expect_equivalent(distinctiveness_alt(valid_mat, dist_mat, 0.4),
-                    good_di_0.4)
+  expect_equal(distinctiveness_alt(valid_mat, dist_mat, 0.4),
+               good_di_0.4)
 
   # 1/2 ≤ T < 1
-  expect_equivalent(distinctiveness_alt(valid_mat, dist_mat, 0.7),
-                    good_di_0.7)
+  expect_equal(distinctiveness_alt(valid_mat, dist_mat, 0.7),
+               good_di_0.7)
 
   # T ≥ 1
-  expect_equivalent(distinctiveness_alt(valid_mat, dist_mat, 1.1),
-                    good_di_1.1)
+  expect_equal(distinctiveness_alt(valid_mat, dist_mat, 1.1),
+               good_di_1.1)
 })
 
 test_that("Correct Di computation with abundance",{
@@ -100,20 +100,20 @@ test_that("Correct Di computation with abundance",{
 
   # Check computation equal
   # T < 1/3
-  expect_equivalent(distinctiveness_alt(abund_mat, dist_mat, 0.1),
-                    good_di_0.1_ab)
+  expect_equal(distinctiveness_alt(abund_mat, dist_mat, 0.1),
+               good_di_0.1_ab)
 
   # 1/3 ≤ T < 1/2
-  expect_equivalent(distinctiveness_alt(abund_mat, dist_mat, 4/10),
-                    good_di_0.4_ab)
+  expect_equal(distinctiveness_alt(abund_mat, dist_mat, 4/10),
+               good_di_0.4_ab)
 
   # 1/2 ≤ T < 1
-  expect_equivalent(distinctiveness_alt(abund_mat, dist_mat, 7/10),
-                    good_di_0.7_ab)
+  expect_equal(distinctiveness_alt(abund_mat, dist_mat, 7/10),
+               good_di_0.7_ab)
 
   # T ≥ 1
-  expect_equivalent(distinctiveness_alt(abund_mat, dist_mat, 11/10),
-                    good_di_1.1_ab)
+  expect_equal(distinctiveness_alt(abund_mat, dist_mat, 11/10),
+               good_di_1.1_ab)
 })
 
 test_that("Distinctiveness works with sparse matrices", {
@@ -122,37 +122,37 @@ test_that("Distinctiveness works with sparse matrices", {
   ## Presence-absence
   # Check computation equal
   # T < 1/3
-  expect_equivalent(distinctiveness_alt(sparse_mat, dist_mat, 1/10),
-                    as(good_di_0.1, "dgeMatrix"))
+  expect_equal(distinctiveness_alt(sparse_mat, dist_mat, 1/10),
+               as(good_di_0.1, "dgeMatrix"))
 
   # 1/3 ≤ T < 1/2
-  expect_equivalent(distinctiveness_alt(sparse_mat, dist_mat, 0.4),
-                    as(good_di_0.4, "dgeMatrix"))
+  expect_equal(distinctiveness_alt(sparse_mat, dist_mat, 0.4),
+               as(good_di_0.4, "dgeMatrix"))
 
   # 1/2 ≤ T < 1
-  expect_equivalent(distinctiveness_alt(sparse_mat, dist_mat, 0.7),
-                    as(good_di_0.7, "dgeMatrix"))
+  expect_equal(distinctiveness_alt(sparse_mat, dist_mat, 0.7),
+               as(good_di_0.7, "dgeMatrix"))
 
   #  T ≥ 1
-  expect_equivalent(distinctiveness_alt(sparse_mat, dist_mat, 1.1),
-                    as(good_di_1.1, "dgeMatrix"))
+  expect_equal(distinctiveness_alt(sparse_mat, dist_mat, 1.1),
+               as(good_di_1.1, "dgeMatrix"))
 
   ## Abundances
   # T < 1/3
-  expect_equivalent(distinctiveness_alt(sparse_ab_mat, dist_mat, 0.1),
-                    as(good_di_0.1_ab, "dgeMatrix"))
+  expect_equal(distinctiveness_alt(sparse_ab_mat, dist_mat, 0.1),
+               as(good_di_0.1_ab, "dgeMatrix"))
 
   # 1/3 ≤ T < 1/2
-  expect_equivalent(distinctiveness_alt(sparse_ab_mat, dist_mat, 4/10),
-                    as(good_di_0.4_ab, "dgeMatrix"))
+  expect_equal(distinctiveness_alt(sparse_ab_mat, dist_mat, 4/10),
+               as(good_di_0.4_ab, "dgeMatrix"))
 
   # 1/2 ≤ T < 1
-  expect_equivalent(distinctiveness_alt(sparse_ab_mat, dist_mat, 7/10),
-                    as(good_di_0.7_ab, "dgeMatrix"))
+  expect_equal(distinctiveness_alt(sparse_ab_mat, dist_mat, 7/10),
+               as(good_di_0.7_ab, "dgeMatrix"))
 
   # T ≥ 1
-  expect_equivalent(distinctiveness_alt(sparse_ab_mat, dist_mat, 11/10),
-                    as(good_di_1.1_ab, "dgeMatrix"))
+  expect_equal(distinctiveness_alt(sparse_ab_mat, dist_mat, 11/10),
+               as(good_di_1.1_ab, "dgeMatrix"))
 })
 
 

--- a/tests/testthat/test-distinctiveness_range.R
+++ b/tests/testthat/test-distinctiveness_range.R
@@ -148,23 +148,23 @@ test_that("Correct Di computation without abundance",{
 
   # Check computation equal
   # When T < 1/9
-  expect_equivalent(distinctiveness_range(valid_mat, dist_mat, 0.1),
-                    good_di_0.1)
+  expect_equal(distinctiveness_range(valid_mat, dist_mat, 0.1),
+               good_di_0.1)
 
   # 1/9 ≤ T < 4/9
-  expect_equivalent(distinctiveness_range(valid_mat, dist_mat, 0.4),
-                    good_di_0.4)
+  expect_equal(distinctiveness_range(valid_mat, dist_mat, 0.4),
+               good_di_0.4)
 
   # 4/9 ≤ T < 8/9
-  expect_equivalent(distinctiveness_range(valid_mat, dist_mat, 0.6),
-                    good_di_0.6)
+  expect_equal(distinctiveness_range(valid_mat, dist_mat, 0.6),
+               good_di_0.6)
 
   #  T ≥ 8/9
-  expect_equivalent(distinctiveness_range(valid_mat, dist_mat, 0.9),
-                    good_di_0.9)
+  expect_equal(distinctiveness_range(valid_mat, dist_mat, 0.9),
+               good_di_0.9)
 
-  expect_equivalent(distinctiveness_range(valid_mat, dist_mat, 4, TRUE),
-                    good_di_relative_max)
+  expect_equal(distinctiveness_range(valid_mat, dist_mat, 4, TRUE),
+               good_di_relative_max)
 })
 
 test_that("Correct Di computation with abundance",{
@@ -175,20 +175,20 @@ test_that("Correct Di computation with abundance",{
 
   # Check computation equal
   # When T < 1/9
-  expect_equivalent(distinctiveness_range(abund_mat, dist_mat, 0.1),
-                    good_di_0.1_ab)
+  expect_equal(distinctiveness_range(abund_mat, dist_mat, 0.1),
+               good_di_0.1_ab)
 
   # 1/9 ≤ T < 4/9
-  expect_equivalent(distinctiveness_range(abund_mat, dist_mat, 0.4),
-                    good_di_0.4_ab)
+  expect_equal(distinctiveness_range(abund_mat, dist_mat, 0.4),
+               good_di_0.4_ab)
 
   # 4/9 ≤ T < 8/9
-  expect_equivalent(distinctiveness_range(abund_mat, dist_mat, 0.6),
-                    good_di_0.6_ab)
+  expect_equal(distinctiveness_range(abund_mat, dist_mat, 0.6),
+               good_di_0.6_ab)
 
   #  T ≥ 8/9
-  expect_equivalent(distinctiveness_range(abund_mat, dist_mat, 0.9),
-                    good_di_0.9_ab)
+  expect_equal(distinctiveness_range(abund_mat, dist_mat, 0.9),
+               good_di_0.9_ab)
 })
 
 test_that("Distinctiveness works with sparse matrices", {
@@ -196,37 +196,37 @@ test_that("Distinctiveness works with sparse matrices", {
 
   ## Presence-absence
   # When T < 1/9
-  expect_equivalent(distinctiveness_range(sparse_mat, dist_mat, 0.1),
-                    as(good_di_0.1, "dgeMatrix"))
+  expect_equal(distinctiveness_range(sparse_mat, dist_mat, 0.1),
+               as(good_di_0.1, "dgeMatrix"))
 
   # 1/9 ≤ T < 4/9
-  expect_equivalent(distinctiveness_range(sparse_mat, dist_mat, 0.4),
-                    as(good_di_0.4, "dgeMatrix"))
+  expect_equal(distinctiveness_range(sparse_mat, dist_mat, 0.4),
+               as(good_di_0.4, "dgeMatrix"))
 
   # 4/9 ≤ T < 8/9
-  expect_equivalent(distinctiveness_range(sparse_mat, dist_mat, 0.6),
-                    as(good_di_0.6, "dgeMatrix"))
+  expect_equal(distinctiveness_range(sparse_mat, dist_mat, 0.6),
+               as(good_di_0.6, "dgeMatrix"))
 
   #  T ≥ 8/9
-  expect_equivalent(distinctiveness_range(sparse_mat, dist_mat, 0.9),
-                    as(good_di_0.9, "dgeMatrix"))
+  expect_equal(distinctiveness_range(sparse_mat, dist_mat, 0.9),
+               as(good_di_0.9, "dgeMatrix"))
 
   ## Abundances
   # When T < 1/9
-  expect_equivalent(distinctiveness_range(sparse_ab_mat, dist_mat, 0.1),
-                    as(good_di_0.1_ab, "dgeMatrix"))
+  expect_equal(distinctiveness_range(sparse_ab_mat, dist_mat, 0.1),
+               as(good_di_0.1_ab, "dgeMatrix"))
 
   # 1/9 ≤ T < 4/9
-  expect_equivalent(distinctiveness_range(sparse_ab_mat, dist_mat, 0.4),
-                    as(good_di_0.4_ab, "dgeMatrix"))
+  expect_equal(distinctiveness_range(sparse_ab_mat, dist_mat, 0.4),
+               as(good_di_0.4_ab, "dgeMatrix"))
 
   # 4/9 ≤ T < 8/9
-  expect_equivalent(distinctiveness_range(sparse_ab_mat, dist_mat, 0.6),
-                    as(good_di_0.6_ab, "dgeMatrix"))
+  expect_equal(distinctiveness_range(sparse_ab_mat, dist_mat, 0.6),
+               as(good_di_0.6_ab, "dgeMatrix"))
 
   #  T ≥ 8/9
-  expect_equivalent(distinctiveness_range(sparse_ab_mat, dist_mat, 0.9),
-                    as(good_di_0.9_ab, "dgeMatrix"))
+  expect_equal(distinctiveness_range(sparse_ab_mat, dist_mat, 0.9),
+               as(good_di_0.9_ab, "dgeMatrix"))
 })
 
 

--- a/tests/testthat/test-rarity_dimensions.R
+++ b/tests/testthat/test-rarity_dimensions.R
@@ -39,7 +39,7 @@ test_that("'distinctiveness_dimensions()' outputs good objects", {
 
   # Check that all elements are matrices
   lapply(di_dim, function(x) {
-    expect_is(x, "matrix")
+    expect_true(inherits(x, "matrix"))
   })
 
   # Check that all elements have good dimension

--- a/tests/testthat/test-restrictedness.R
+++ b/tests/testthat/test-restrictedness.R
@@ -46,8 +46,8 @@ test_that("Restrictedness works with sparse matrices", {
 
   expect_silent(restrictedness(sparse_mat))
 
-  expect_equivalent(restrictedness(sparse_mat),
-                    data.frame("species" = letters[1:4],
-                               "Ri" = c(3/4, 1/4, 1/4, 1/2)))
+  expect_equal(restrictedness(sparse_mat),
+               data.frame("species" = letters[1:4],
+                          "Ri" = c(3/4, 1/4, 1/4, 1/2)))
 })
 

--- a/tests/testthat/test-tidy_matrix.R
+++ b/tests/testthat/test-tidy_matrix.R
@@ -62,9 +62,9 @@ na_mat["d", "s4"] = NA
 
 test_that("Conversion from tidy data.frame to matrix works", {
 
-  expect_equivalent(stack_to_matrix(com_df, "species", "site"), valid_mat)
-  expect_equivalent(stack_to_matrix(abund_df, "species", "site", "val"),
-                    abund_mat)
+  expect_equal(unname(stack_to_matrix(com_df, "species", "site")), unname(valid_mat))
+  expect_equal(stack_to_matrix(abund_df, "species", "site", "val"),
+               abund_mat)
 
   expect_error(stack_to_matrix(com_df, "speies", "site"),
                label = "Column 'speies' is not in data.frame")
@@ -77,16 +77,16 @@ test_that("Conversion from tidy data.frame to matrix works", {
 
 test_that("Conversion from matrix to tidy data.frame works", {
 
-  expect_equivalent(matrix_to_stack(valid_mat, row_to_col = "species",
-                                   col_to_col = "site")[, -3], com_df)
+  expect_equal(matrix_to_stack(valid_mat, row_to_col = "species",
+                               col_to_col = "site")[, -3], com_df)
 
-  expect_equivalent(matrix_to_stack(abund_mat, value_col = "val"), abund_df)
+  expect_equal(matrix_to_stack(abund_mat, value_col = "val"), abund_df)
 
   expect_equal(colnames(matrix_to_stack(valid_mat, row_to_col = NULL,
-                              col_to_col = "site"))[2], "row")
+                                        col_to_col = "site"))[2], "row")
 
   expect_equal(colnames(matrix_to_stack(valid_mat, row_to_col = "species",
-                              col_to_col = NULL))[1], "col")
+                                        col_to_col = NULL))[1], "col")
 })
 
 test_that("Conversion from sparse & dense matrices to tidy data.frame", {
@@ -99,29 +99,29 @@ test_that("Conversion from sparse & dense matrices to tidy data.frame", {
   abund_dens   = as(abund_mat, "Matrix")
 
   # Test for sparse matrices
-  expect_equivalent(matrix_to_stack(valid_sparse, row_to_col = "species",
-                                    col_to_col = "site")[, -3], com_df)
+  expect_equal(matrix_to_stack(valid_sparse, row_to_col = "species",
+                               col_to_col = "site")[, -3], com_df)
 
-  expect_equivalent(matrix_to_stack(abund_sparse, value_col = "val"), abund_df)
+  expect_equal(matrix_to_stack(abund_sparse, value_col = "val"), abund_df)
 
   expect_equal(colnames(matrix_to_stack(valid_sparse, row_to_col = NULL,
-                               col_to_col = "site"))[2], "row")
+                                        col_to_col = "site"))[2], "row")
 
   expect_equal(colnames(matrix_to_stack(valid_sparse, row_to_col = "species",
-                               col_to_col = NULL))[1], "col")
+                                        col_to_col = NULL))[1], "col")
 
 
   # Test for dense matrices
-  expect_equivalent(matrix_to_stack(valid_dens, row_to_col = "species",
-                                    col_to_col = "site")[, -3], com_df)
+  expect_equal(matrix_to_stack(valid_dens, row_to_col = "species",
+                               col_to_col = "site")[, -3], com_df)
 
-  expect_equivalent(matrix_to_stack(abund_dens, value_col = "val"), abund_df)
+  expect_equal(matrix_to_stack(abund_dens, value_col = "val"), abund_df)
 
   expect_equal(colnames(matrix_to_stack(valid_dens, row_to_col = NULL,
-                               col_to_col = "site"))[2], "row")
+                                        col_to_col = "site"))[2], "row")
 
   expect_equal(colnames(matrix_to_stack(valid_dens, row_to_col = "species",
-                               col_to_col = NULL))[1], "col")
+                                        col_to_col = NULL))[1], "col")
 })
 
 test_that("Conversion from tidy data.frame to sparse & dense matrices", {

--- a/tests/testthat/test-uniqueness.R
+++ b/tests/testthat/test-uniqueness.R
@@ -63,8 +63,8 @@ test_that("Correct Uniqueness computation", {
   all_ui = data.frame(species = letters[1:4],
                       Ui = c(1/9, 1/9, 4/9, 4/9))
 
-  expect_equivalent(uniqueness_stack(com_df[1:2, ], "species", dist_mat),
-                    valid_ui)
+  expect_equal(uniqueness_stack(com_df[1:2, ], "species", dist_mat),
+               valid_ui)
 
   expect_error(uniqueness_stack(com_df[1:2, ], "NOT_IN_TABLE", dist_mat),
                regexp = "'NOT_IN_TABLE' column not in provided data.frame")
@@ -74,7 +74,7 @@ test_that("Correct Uniqueness computation", {
     regexp = "^More species in community data.frame than in distance matrix.*"
   )
 
-  expect_equivalent(uniqueness_stack(com_df, "species", dist_mat), all_ui)
+  expect_equal(uniqueness_stack(com_df, "species", dist_mat), all_ui)
 
   expect_equal(uniqueness(valid_mat, dist_mat), all_ui)
 })


### PR DESCRIPTION
- [x] Update `DESCRIPTION` to use testthat v3
- [x] Replace all deprecated expect_equivalent() calls 
- [x] Replace deprecated expect_is() calls
- [ ] Remove deprecated `context()` calls. I leave this to you since I don't know if you prefer to remove them entirely, leave them as comments, etc.